### PR TITLE
setup workspace before apply changes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/terraform/TerraformBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/terraform/TerraformBuildWrapper.java
@@ -185,7 +185,7 @@ public class TerraformBuildWrapper extends BuildWrapper {
     public void executeApply(AbstractBuild build, final Launcher launcher, final BuildListener listener) throws Exception {
         ArgumentListBuilder args = new ArgumentListBuilder();
         EnvVars env = build.getEnvironment(listener);
-        workspacePath = new FilePath(build.getWorkspace(), WORK_DIR_NAME);
+        setupWorkspace(build, env);
 
         String executable = getExecutable(env, listener, launcher);
         args.add(executable);


### PR DESCRIPTION
I'm not sure if there's any special reason for that, but if we set the workspace when using terraform get (using the setupWorkspace method) we should set it to the same when we apply.

If we don't do that, when we set the workspace to another folder (to read the .tf files), it'll download the external modules on that folder, and when it runs apply it does from a different one (the terraform-plugin I guess) where there's no .tf files to run.

I believe that's related to #3 .

If the reason for that is to run from a folder unrelated to the project, that solution does not apply. Our use case is having a few extra modules on other repos and managing tfstate on a remote file on S3.